### PR TITLE
Ensure relative asset paths are resolved relative to lein root direct…

### DIFF
--- a/src/leiningen/minify_assets.clj
+++ b/src/leiningen/minify_assets.clj
@@ -88,11 +88,17 @@
     (for [path (watch-paths sources)]
       (watch-thread path (event-handler (apply assoc {} asset) options)))))
 
+(defn- normalize-path [root path]
+  (let [f (file path)]
+    (.getAbsolutePath (if (or (.isAbsolute f) (.startsWith (.getPath f) "\\"))
+                        f (file root path)))))
+
 (defn minify-assets [project & opts]
   (try
     (let [watch? (some #{"watch"} opts)
           profile (first (remove #{"watch"} opts))
-          {:keys [assets options]} (extract-options project profile)]
+          {:keys [in-assets options]} (extract-options project profile)
+          assets (map #(normalize-path (:root project) %) in-assets)]
       (when (and watch? (unsupported-version?))
         (throw (InvalidParameterException. "watching for changes is only supported on JDK 1.7+")))
       (if watch?


### PR DESCRIPTION
yogthos, can you check my commit. It fixes assets given as relative paths, by ensuring they are resolved with respect to lein project root (:root project). This is needed for nested projects that use plugins such as lein-sub or lein-modules. Please see issue https://github.com/kumarshantanu/lein-sub/issues/13 which discusses the problem. 

normalize-path was taken from leiningen.core.classpath

With this fix, I can then compile and install sub modules that include assets to minify via lein sub install.

R