### PR TITLE
Fix for #8 vector of sources

### DIFF
--- a/src/leiningen/minify_assets.clj
+++ b/src/leiningen/minify_assets.clj
@@ -89,9 +89,11 @@
       (watch-thread path (event-handler (apply assoc {} asset) options)))))
 
 (defn- normalize-path [root path]
-  (let [f (file path)]
-    (.getAbsolutePath (if (or (.isAbsolute f) (.startsWith (.getPath f) "\\"))
-                        f (file root path)))))
+  (if (vector? path)
+    (into [] (map #(normalize-path root %) path))
+    (let [f (file path)]
+      (.getAbsolutePath (if (or (.isAbsolute f) (.startsWith (.getPath f) "\\"))
+                          f (file root path))))))
 
 (defn minify-assets [project & opts]
   (try


### PR DESCRIPTION
0.2.6 lost the ability to merge multiple sources into a single minified asset. Now fixed

minifying assets...

minifying: /private/tmp/t/resources/site.min.css
assets: site.css
original size: 146082
compressed size: 121380
gzipped size: 19913

minifying: /private/tmp/t/resources/all.min.css
assets: site.css, o.css
original size: 292164
compressed size: 242760
gzipped size: 39187
Created /private/tmp/t/target/t-0.1.0-SNAPSHOT.jar
Wrote /private/tmp/t/pom.xml
Installed jar and pom into local repo.
all.min.css	o.css		site.css	site.min.css