### PR TITLE
changed hook invocation order

### DIFF
--- a/src/minify_assets/plugin.clj
+++ b/src/minify_assets/plugin.clj
@@ -4,8 +4,8 @@
             [leiningen.minify-assets :refer [minify-assets]]))
 
 (defn add-minify-assets-hook [f & args]
-  (minify-assets (first args))
-  (apply f args))
+  (apply f args)
+  (minify-assets (first args)))
 
 (defn hooks []
   (robert.hooke/add-hook #'leiningen.compile/compile


### PR DESCRIPTION
Hi Dmitri,

This pull requests changes the order of the hook invocation. The motivation is to have same order with other plugins (most of them invoke their code after wrapped function). For instance if someone wants to use two plugins and they have different order of hook invocation then it can not be defined by the order of declaration in :hooks.

:plugins [[lein-less "1.7.5"]
            [lein-asset-minifier "0.3.0"]]
  :hooks [leiningen.less
          minify-assets.plugin/hooks]

leiningen.less and minify-assets.plugin/hooks have different order. It leads to minify-assets.plugin/hooks is always run first.

;https://github.com/yogthos/lein-asset-minifier/blob/master/src/minify_assets/plugin.clj
(defn add-minify-assets-hook [f & args]
  (minify-assets (first args))
  (apply f args))

;https://github.com/montoux/lein-less/blob/master/src/leiningen/less.clj
(defn compile-hook [task & args]
  (apply task args)
  (run-compiler (first args) (config (first args)) false))

As a results:
```
(defn add-minify-assets-hook [f & args]
  (minify-assets (first args))
  (defn compile-hook [task & args]
    (apply task args)
    (run-compiler (first args) (config (first args)) false)))
```

or

```
(defn compile-hook [task & args]
  (defn add-minify-assets-hook [f & args]
    (minify-assets (first args))
    (apply f args))
  (run-compiler (first args) (config (first args)) false))
```

PS: Not sure, whether it breaks any project configurations based on this order.
Thanks.