### PR TITLE
chore: bump dependency version to fix warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [asset-minifier "0.2.7"]
-                 [org.clojure/core.async "0.4.490"]]
+                 [org.clojure/core.async "1.6.681"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
When using this plugin in conjunction with [Clojure `1.11`](https://github.com/clojure/clojure/blob/master/changes.md#33-update-keys-and-update-vals) we see errors of the form `WARNING: update-vals already refers to: #'clojure.core/update-vals in namespace: clojure.tools.analyzer.utils, being replaced by: #'clojure.tools.analyzer.utils/update-vals`. 

When upgrading `org.clojure/core.async` to the latest version we no longer see these warnings.

Could we please merge this change and cut a new release?